### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,14 +2,18 @@
 
 The following is the list of current maintainers this repo:
 
+**Active maintainers**
 | Name              | GitHub          | Email                        | LFID              |
 | ----------------- | --------------- | ---------------------------- | ----------------- |
 | Andrew Richardson | awrichar        | andrew.richardson@kaleido.io | Andrew.Richardson |
-| Alex Shorsher     | shorsher        | alex.shorsher@kaleido.io     | shorsher          |
 | Nicko Guyer       | nguyer          | nicko.guyer@kaleido.io       | nguyer            |
 | Peter Broadhurst  | peterbroadhurst | peter.broadhurst@kaleido.io  | peterbroadhurst   |
 
 
+**Emeritus maintainers**
+| Name              | GitHub          | Email                        | LFID              |
+| ----------------- | --------------- | ---------------------------- | ----------------- |
+| Alex Shorsher     | shorsher        | alex.shorsher@kaleido.io     | shorsher          |
 This list is to be kept up to date as maintainers are added or removed.
 
 # Expectations of Maintainers


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>